### PR TITLE
Ensure level reset resumes gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -552,7 +552,8 @@
   }
 
   function resetLevel(){
-    score = 0; lives = 3; buildLevel(); flash("スタート！");
+    score = 0; lives = 3; paused = false;
+    buildLevel(); flash("スタート！");
   }
   function respawn(){
     // スタート地点へ戻す


### PR DESCRIPTION
## Summary
- Resetting the level now clears the paused state so movement works again

## Testing
- `node -e "console.log('no tests')"`


------
https://chatgpt.com/codex/tasks/task_e_689d5ef75e808331a098347c67043e47