### PR TITLE
Enable tap-anywhere jumping on touch devices

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,14 @@
   bindHold(document.querySelector('[data-right]'), v=>keys.stop=v);
   bindHold(document.querySelector('[data-jump]'),  v=>{ if (v) keys.up=true; });
 
+  // 画面のどこをタップしてもジャンプ
+  document.getElementById('game').addEventListener('pointerdown', e => {
+    if (!e.target.closest('.btn')) {
+      e.preventDefault();
+      keys.up = true;
+    }
+  });
+
   // ===== キャンバス =====
   const cv = document.getElementById('cv');
   const ctx = cv.getContext('2d');


### PR DESCRIPTION
## Summary
- allow tapping anywhere on the game area to trigger a jump, except on control buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dfa4df8288331a27479e5b57e9fa5