### PR TITLE
Hide jump button on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,9 +52,6 @@
       <div class="pad">
         <div class="btn" data-slow>▼</div>
       </div>
-      <div class="pad">
-        <div class="btn" data-jump>⤴</div>
-      </div>
     </div>
   </div>
 </div>
@@ -102,7 +99,6 @@
     addEventListener('pointerleave', off);
   };
   bindHold(document.querySelector('[data-slow]'), v=>keys.slow=v);
-  bindHold(document.querySelector('[data-jump]'),  v=>{ if (v) keys.up=true; });
 
   // 画面のどこをタップしてもジャンプ
   document.getElementById('game').addEventListener('pointerdown', e => {


### PR DESCRIPTION
## Summary
- Remove jump soft button to avoid showing it on mobile devices

## Testing
- `npm test` (fails: ENOENT, no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a0501317488331970539755df69433