### PR TITLE
ゲーム終了時に再挑戦とリセットのボタンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,18 @@
   @media (min-width: 900px) {
     #controls { display:none; }
   }
+
+  #menu {
+    position:absolute; left:50%; top:50%; transform:translate(-50%,-50%);
+    display:none; flex-direction:column; gap:12px;
+    background:#ffffffd8; padding:20px; border-radius:12px;
+    box-shadow:0 4px 12px #00000020; z-index:4;
+  }
+  #menu button {
+    padding:8px 16px; border:none; border-radius:8px; background:#fff;
+    box-shadow:0 2px 6px #00000020; font-weight:700; color:#5a6a7a;
+  }
+  #menu button:active { transform: translateY(2px); }
 </style>
 </head>
 <body>
@@ -52,6 +64,10 @@
       <div class="pad">
         <div class="btn" data-slow>▼</div>
       </div>
+    </div>
+    <div id="menu">
+      <button id="retryBtn">再挑戦</button>
+      <button id="resetBtn">リセット</button>
     </div>
   </div>
 </div>
@@ -102,7 +118,7 @@
 
   // 画面のどこをタップしてもジャンプ
   document.getElementById('game').addEventListener('pointerdown', e => {
-    if (!e.target.closest('.btn')) {
+    if (!e.target.closest('.btn') && !e.target.closest('#menu')) {
       e.preventDefault();
       keys.up = true;
     }
@@ -560,6 +576,11 @@
   const elScore = document.getElementById('score');
   const elLives = document.getElementById('lives');
   const elMsg   = document.getElementById('msg');
+  const elMenu  = document.getElementById('menu');
+  const btnRetry = document.getElementById('retryBtn');
+  const btnReset = document.getElementById('resetBtn');
+  btnRetry.addEventListener('click', () => { resetLevel(); });
+  btnReset.addEventListener('click', () => { location.reload(); });
   let score = 0, lives = 3;
   function updateHUD(){
     elScore.textContent = `★ ${score}`;
@@ -596,6 +617,7 @@
   }
 
   function resetLevel(){
+    elMenu.style.display = 'none';
     score = 0; lives = 3; paused = false;
     generateLevel();
     buildLevel(); flash("スタート！");
@@ -611,8 +633,8 @@
       }
     }
   }
-  function win(){ flash("クリア！おめでとう🎉"); paused=true; }
-  function lose(){ flash("ゲームオーバー… Rで再挑戦"); paused=true; }
+  function win(){ flash("クリア！おめでとう🎉"); paused=true; elMenu.style.display='flex'; }
+  function lose(){ flash("ゲームオーバー…"); paused=true; elMenu.style.display='flex'; }
 
   // ===== メインループ =====
   let last=0, paused=false;


### PR DESCRIPTION
## Summary
- ゲームクリア/オーバー時に再挑戦・リセットボタンを表示
- リセットボタンでページをリロード

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a056670c4c8331b9902a6a3ac49c11