### PR TITLE
Add stage progression with countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,14 +249,14 @@
       this.blink=0;
     }
     update(dt){
-      const speed = 160;
       const accel = 1400;
       const decc  = 1800;
       const maxFall = 900;
       const jumpV = 620;
 
-      // 自動で右に進む。キー入力で低速。
-      const maxSpeed = keys.slow ? 80 : 160;
+      // 自動で右に進む。キー入力で低速。ステージが進むと速度アップ
+      const baseSpeed = getStageSpeed();
+      const maxSpeed = keys.slow ? baseSpeed * 0.5 : baseSpeed;
       this.facing = 1;
 
       // 水平速度
@@ -598,7 +598,10 @@
   const btnReset = document.getElementById('resetBtn');
   btnRetry.addEventListener('click', () => { resetLevel(); });
   btnReset.addEventListener('click', () => { location.reload(); });
-  let score = 0, lives = 3;
+  let score = 0, lives = 3, stage = 1;
+  function getStageSpeed(){
+    return 160 + (stage-1) * 10;
+  }
   function updateHUD(){
     elScore.textContent = `★ ${score}`;
     elLives.textContent = `♥ ${lives}`;
@@ -633,11 +636,29 @@
     if (!flag) flag = new Flag((mapW-3)*TILE, (mapH-2)*TILE);
   }
 
+  function startStage(){
+    paused = true;
+    flash(`ステージ${stage}`, 1);
+    let count = 3;
+    const countdown = () => {
+      flash(`${count}`, 1);
+      if (count > 1){
+        count--;
+        setTimeout(countdown, 1000);
+      } else {
+        setTimeout(() => { flash('スタート！', 1); paused = false; }, 1000);
+      }
+    };
+    setTimeout(countdown, 1000);
+  }
+
   function resetLevel(){
     elMenu.style.display = 'none';
-    score = 0; lives = 3; paused = false;
+    score = 0; lives = 3; stage = 1;
+    updateHUD();
     generateLevel();
-    buildLevel(); flash("スタート！");
+    buildLevel();
+    startStage();
   }
   function respawn(){
     // スタート地点へ戻す
@@ -650,7 +671,16 @@
       }
     }
   }
-  function win(){ flash("クリア！おめでとう🎉"); paused=true; elMenu.style.display='flex'; }
+  function win(){
+    paused = true;
+    flash('クリア！', 1);
+    stage++;
+    setTimeout(() => {
+      generateLevel();
+      buildLevel();
+      startStage();
+    }, 1000);
+  }
   function lose(){ flash("ゲームオーバー…"); paused=true; elMenu.style.display='flex'; }
 
   // ===== メインループ =====
@@ -775,6 +805,7 @@
   // ===== スタート！ =====
   generateLevel();
   buildLevel();
+  startStage();
   requestAnimationFrame(step);
 
 })();


### PR DESCRIPTION
## Summary
- Introduce stage system with countdown and speed scaling
- Automatically advance to the next stage after reaching the goal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05a29ab2483319acd02dd6416e223